### PR TITLE
Allow the collector.paths section of the config to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ module "collector_lb" {
 | <a name="input_topic_project_id"></a> [topic\_project\_id](#input\_topic\_project\_id) | The project ID in which the topics are deployed | `string` | n/a | yes |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Whether to assign a public ip address to this instance; if false this instance must be behind a Cloud NAT to connect to the internet | `bool` | `true` | no |
 | <a name="input_byte_limit"></a> [byte\_limit](#input\_byte\_limit) | The amount of bytes to buffer events before pushing them to PubSub | `number` | `1000000` | no |
+| <a name="input_custom_paths"></a> [custom\_paths](#input\_custom\_paths) | Optional custom paths that the collector will respond to, refer to [collector docs](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/stream-collector/configure/#configuring-custom-paths) for structure | `map(string)` | `{}` | no |
 | <a name="input_cookie_domain"></a> [cookie\_domain](#input\_cookie\_domain) | Optional first party cookie domain for the collector to set cookies on (e.g. acme.com) | `string` | `""` | no |
 | <a name="input_gcp_logs_enabled"></a> [gcp\_logs\_enabled](#input\_gcp\_logs\_enabled) | Whether application logs should be reported to GCP Logging | `bool` | `true` | no |
 | <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | The path to bind for health checks | `string` | `"/health"` | no |

--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,7 @@ resource "google_compute_firewall" "egress" {
 locals {
   collector_hocon = templatefile("${path.module}/templates/config.hocon.tmpl", {
     port            = var.ingress_port
+    paths           = var.custom_paths
     cookie_domain   = var.cookie_domain
     good_topic_name = var.good_topic_name
     bad_topic_name  = var.bad_topic_name

--- a/templates/config.hocon.tmpl
+++ b/templates/config.hocon.tmpl
@@ -6,7 +6,11 @@ collector {
     redirect = false
     port = 8443
   }
-  paths {}
+  paths {
+%{ for custompath, defaultpath in paths ~}
+    "${custompath}"    = "${defaultpath}"
+%{ endfor ~}
+  }
   p3p {
     policyRef = "/w3c/p3p.xml"
     CP = "NOI DSP COR NID PSA OUR IND COM NAV STA"

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,12 @@ variable "bad_topic_name" {
   type        = string
 }
 
+variable "custom_paths" {
+  description = "Optional custom paths that the collector will respond to"
+  default     = {}
+  type        = map(string)
+}
+
 variable "cookie_domain" {
   description = "Optional first party cookie domain for the collector to set cookies on (e.g. acme.com)"
   default     = ""


### PR DESCRIPTION
Previously, the `paths {}` section of the collector config was hardcoded to an empty map. This allows the user to configure the paths via an input, which will get added to the config if defined. I've updated the README accordingly.

With no paths defined, Terraform will output:

```
  paths {
  }
```

And with paths defined:

```
  paths {
    "/com.acme/track"    = "/com.snowplowanalytics.snowplow/tp2"
    "/com.acme/redirect"    = "/r/tp2"
    "/com.acme/iglu"    = "/com.snowplowanalytics.iglu/v1"
  }
```