### PR TITLE
fix: Add network_project_id to support shared VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ module "collector_lb" {
 | <a name="input_name"></a> [name](#input\_name) | A name which will be pre-pended to the resources created | `string` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | The name of the network to deploy within | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID in which the stack is being deployed | `string` | n/a | yes |
+| <a name="input_network_project_id"></a> [network\_project\_id](#input\_network\_project\_id) | The project ID of the shared VPC in which the stack is being deployed | `string` | `""` | no |
 | <a name="input_region"></a> [region](#input\_region) | The name of the region to deploy within | `string` | n/a | yes |
 | <a name="input_topic_project_id"></a> [topic\_project\_id](#input\_topic\_project\_id) | The project ID in which the topics are deployed | `string` | n/a | yes |
 | <a name="input_accept_limited_use_license"></a> [accept\_limited\_use\_license](#input\_accept\_limited\_use\_license) | Acceptance of the SLULA terms (https://docs.snowplow.io/limited-use-license-1.0/) | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,8 @@ resource "google_project_iam_member" "sa_logging_log_writer" {
 # --- CE: Firewall rules
 
 resource "google_compute_firewall" "ingress_ssh" {
-  name = "${var.name}-ssh-in"
+  project = (var.network_project_id != "") ? var.network_project_id : var.project_id
+  name    = "${var.name}-ssh-in"
 
   network     = var.network
   target_tags = [var.name]
@@ -82,7 +83,8 @@ resource "google_compute_firewall" "ingress_ssh" {
 #
 # https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges
 resource "google_compute_firewall" "ingress" {
-  name = "${var.name}-traffic-in"
+  project = (var.network_project_id != "") ? var.network_project_id : var.project_id
+  name    = "${var.name}-traffic-in"
 
   network     = var.network
   target_tags = [var.name]
@@ -96,7 +98,8 @@ resource "google_compute_firewall" "ingress" {
 }
 
 resource "google_compute_firewall" "egress" {
-  name = "${var.name}-traffic-out"
+  project = (var.network_project_id != "") ? var.network_project_id : var.project_id
+  name    = "${var.name}-traffic-out"
 
   network     = var.network
   target_tags = [var.name]

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,12 @@ variable "project_id" {
   type        = string
 }
 
+variable "network_project_id" {
+  description = "The project ID of the shared VPC in which the stack is being deployed"
+  type        = string
+  default     = ""
+}
+
 variable "region" {
   description = "The name of the region to deploy within"
   type        = string


### PR DESCRIPTION
# Background

Google has [Shared VPC](https://cloud.google.com/vpc/docs/shared-vpc) network topology. If we'd like to apply to a shared VPC, the current module will fail when trying to create firewall rules.

# Proposed solution

Add `network_project_id` variable as optional and allow backward compatible in case ppl using this module with `~>` in the source `version`.

## Added
- [x] `network_project_id` variable to support a shared VPC setup

## Changed
- [x] Update `README.md`
